### PR TITLE
no longer reloads on clicking an entity

### DIFF
--- a/frontend/src/components/handles/HandlesList.vue
+++ b/frontend/src/components/handles/HandlesList.vue
@@ -60,13 +60,10 @@
         if(this.oldEntity === this.entity){
           bus.$emit('FETCH_DATA')
         }
-        else{
-          this.oldEntity = this.entity
-        }
-
-
+      },
+      entity: function() {
+        this.oldEntity = this.entity
       }
-
     },
     methods: {
       addToActiveHandles: function(handleID){


### PR DESCRIPTION
The method fetchData is no longer unnecessarily called upon whenever you click on an entity several times (not (de)activating, just opening the handles).