### PR TITLE
Bugfix

### DIFF
--- a/frontend/src/components/entities/EntitiesList.vue
+++ b/frontend/src/components/entities/EntitiesList.vue
@@ -64,9 +64,12 @@
     },
     watch: {
       entities : function () {
+        this.entitiesIsEmpty = (this.entities.length === 0)
+        bus.$emit('ENTITIES_IS_EMPTY', this.entitiesIsEmpty)
         // this.activeEntities = this.entities.filter(e => e.active).map(e => e.id)
       },
       activeEntities : function(){
+
         //saveActiveEntities(this.activeEntities);
         this.updateLocalStorage()
         //bus.$emit('UPDATE_ACTIVE_HANDLES', this.activeHandles)
@@ -84,8 +87,7 @@
             this.searchNotFound = false
           }
         }
-        this.entitiesIsEmpty = (found.length === 0)
-        bus.$emit('ENTITIES_IS_EMPTY', this.entitiesIsEmpty)
+        
         return found
       },
     },


### PR DESCRIPTION
The empty states should now only show up when there are no entities instead of when there are no active entities. Previously when the user entered a search with zero members as result it would incorrectly show the empty states.